### PR TITLE
Fixes for GTAW/SMAW Certificate Forms and Print View

### DIFF
--- a/public/js/gtaw-smaw-certificate-form.js
+++ b/public/js/gtaw-smaw-certificate-form.js
@@ -1284,67 +1284,61 @@ function updateFillerProductFormRange() {
 function updateTestFields() {
     const rtCheckbox = document.getElementById('rt');
     const utCheckbox = document.getElementById('ut');
+
+    const evaluatedByField = document.querySelector('input[name="evaluated_by"]');
     const evaluatedCompanyField = document.querySelector('input[name="evaluated_company"]');
     const mechanicalTestsField = document.querySelector('input[name="mechanical_tests_by"]');
     const labTestNoField = document.querySelector('input[name="lab_test_no"]');
-    
+    const supervisedByField = document.querySelector('input[name="supervised_by"]');
+
+    const fields = [
+        evaluatedByField,
+        evaluatedCompanyField,
+        mechanicalTestsField,
+        labTestNoField,
+        supervisedByField
+    ];
+
     if (!rtCheckbox || !utCheckbox) return;
-    
+
     const updateField = () => {
-        if (rtCheckbox.checked || utCheckbox.checked) {
-            // For evaluated_company field
-            if (evaluatedCompanyField) {
-                evaluatedCompanyField.removeAttribute('required');
-                evaluatedCompanyField.readOnly = false;
-                evaluatedCompanyField.value = '';
-                evaluatedCompanyField.placeholder = 'Not required with RT/UT';
-                evaluatedCompanyField.disabled = true;
-            }
-            
-            // For mechanical_tests_by field
+        const isRtUtChecked = rtCheckbox.checked || utCheckbox.checked;
+
+        if (isRtUtChecked) {
+            // Optional when RT/UT is checked
+            fields.forEach(field => {
+                if (field) {
+                    field.removeAttribute('required');
+                    field.disabled = true;
+                    field.value = '';
+                }
+            });
             if (mechanicalTestsField) {
-                mechanicalTestsField.removeAttribute('disabled');
-                // Remove required attribute to prevent backend validation
-                mechanicalTestsField.removeAttribute('required');
+                mechanicalTestsField.disabled = false;
             }
-            
-            // For lab_test_no field
             if (labTestNoField) {
-                labTestNoField.removeAttribute('disabled');
-                // Remove required attribute to prevent backend validation
-                labTestNoField.removeAttribute('required');
+                labTestNoField.disabled = false;
             }
         } else {
-            // For evaluated_company field
-            if (evaluatedCompanyField) {
-                evaluatedCompanyField.setAttribute('required', 'required');
-                evaluatedCompanyField.readOnly = true;
-                evaluatedCompanyField.value = 'SOGEC';
-                evaluatedCompanyField.placeholder = '';
-                evaluatedCompanyField.disabled = false;
-            }
-            
-            // For mechanical_tests_by field
-            if (mechanicalTestsField) {
-                mechanicalTestsField.setAttribute('disabled', 'disabled');
-                // Already removed required attribute
-                mechanicalTestsField.value = '';
-            }
-            
-            // For lab_test_no field
-            if (labTestNoField) {
-                labTestNoField.setAttribute('disabled', 'disabled');
-                // Already removed required attribute
-                labTestNoField.value = '';
-            }
+            // Mandatory when RT/UT is NOT checked
+            fields.forEach(field => {
+                if (field) {
+                    field.setAttribute('required', 'required');
+                    field.disabled = false;
+                }
+            });
+        }
+
+        // Always keep evaluated_company editable
+        if (evaluatedCompanyField) {
+            evaluatedCompanyField.readOnly = false;
+            evaluatedCompanyField.disabled = false;
         }
     };
-    
-    // Add event listeners
+
     rtCheckbox.addEventListener('change', updateField);
     utCheckbox.addEventListener('change', updateField);
-    
-    // Initialize on page load
+
     updateField();
 }
 

--- a/resources/views/gtaw_smaw_certificates/certificate.blade.php
+++ b/resources/views/gtaw_smaw_certificates/certificate.blade.php
@@ -591,7 +591,11 @@
                 </td>
                 <td class="var-range">{{ $certificate->f_number_range }}</td>
             </tr>
-
+            <tr>
+                <td class="var-label">Consumable insert (GTAW, PAW, LBW):</td>
+                <td class="var-value">{{ $certificate->consumable_insert ?? 'Not Applicable' }}</td>
+                <td class="var-range">{{ $certificate->consumable_insert_range ?? 'Not Applicable' }}</td>
+            </tr>
             <tr>
                 <td class="var-label">Filler Metal Product Form (QW-404.23) (GTAW or PAW):</td>
                 <td class="var-value">
@@ -624,7 +628,7 @@
             </tr>
             <tr>
                 <td class="var-label">
-                    Process 1 __ 3 layers minimum
+                    Process 2 __ 3 layers minimum
                     <div style="display: inline-block; margin-left: 10px;">
                         <span style="display: inline-block; width: 14px; height: 14px; border: 1px solid #000; margin-right: 5px; text-align: center; line-height: 12px;">
                             {!! $certificate->gtaw_process == 1 ? '✓' : '&nbsp;' !!}
@@ -641,7 +645,7 @@
             </tr>
              <tr>
                 <td class="var-label">
-                    Process 2 __ 3 layers minimum
+                    Process 1 __ 3 layers minimum
                     <div style="display: inline-block; margin-left: 10px;">
                         <span style="display: inline-block; width: 14px; height: 14px; border: 1px solid #000; margin-right: 5px; text-align: center; line-height: 12px;">
                             {!! $certificate->smaw_process == 1 ? '✓' : '&nbsp;' !!}

--- a/resources/views/gtaw_smaw_certificates/partials/results-section.blade.php
+++ b/resources/views/gtaw_smaw_certificates/partials/results-section.blade.php
@@ -214,7 +214,7 @@
             </td>
             <td class="var-label">Company</td>
             <td class="var-value" style="text-align: center;">
-                <input type="text" class="form-input" name="evaluated_company" value="SOGEC" readonly>
+                <input type="text" class="form-input" name="evaluated_company" value="SOGEC">
             </td>
         </tr>
         <tr>
@@ -234,7 +234,7 @@
             </td>
             <td class="var-label">Company</td>
             <td class="var-value" style="text-align: center;">
-                <input type="text" class="form-input" name="supervised_company" value="{{ \App\Models\AppSetting::getValue('system_name', 'ELITE') }}" readonly>
+                <input type="text" class="form-input" name="supervised_company" value="Elite Engineering Arabia" readonly>
             </td>
         </tr>
     </table>
@@ -244,7 +244,7 @@
         <strong>We certify that the statements in this record are correct and that the test coupons were prepared, welded, and tested in accordance with the requirements of Section IX of the ASME BOILER AND PRESSURE VESSEL CODE.</strong>
         <span class="custom-certification-wrapper">
             <input type="text" name="certification_text" id="certification_text" class="custom-certification-input" 
-                value="{{ $certificate->certification_text ?? '' }}" placeholder="Add custom certification text here">
+                value="{{ $certificate->certification_text ?? '' }}" placeholder="Add custom certification text here" required>
         </span>
     </div>
 

--- a/resources/views/gtaw_smaw_certificates/partials/welding-variables.blade.php
+++ b/resources/views/gtaw_smaw_certificates/partials/welding-variables.blade.php
@@ -168,10 +168,10 @@
     <tr>
         <td class="var-label">Consumable insert (GTAW, PAW, LBW):</td>
         <td class="var-value">
-            <input type="text" class="form-input" value="Not Applicable" disabled name="consumable_insert" placeholder="Not Applicable">
+            <input type="text" class="form-input" value="Not Applicable" readonly name="consumable_insert" placeholder="Not Applicable">
         </td>
         <td class="var-range">
-            <input type="text" class="form-input" value="Not Applicable" disabled name="consumable_insert_range"
+            <input type="text" class="form-input" value="Not Applicable" readonly name="consumable_insert_range"
                 placeholder="Not Applicable">
         </td>
     </tr>
@@ -179,8 +179,8 @@
         <td class="var-label">Filler Metal Product Form (QW-404.23) (GTAW or PAW):</td>
         <td class="var-value">
             <select class="form-select" name="filler_product_form" id="filler_product_form" onchange="updateFillerProductFormRange()">
-                <option value="bare (solid)">bare (solid)</option>
-                <option value="flux cored">flux cored</option>
+                <option value="bare (solid or metal cored)">bare (solid or metal cored)</option>
+                <option value="range">flux cored</option>
                 <option value="__manual__">Manual Entry</option>
             </select>
             <input type="text" class="form-input" name="filler_product_form_manual" id="filler_product_form_manual"
@@ -212,7 +212,7 @@
     </tr>
     <tr>
         <td class="var-label">
-    Process 2 __ 3 layers minimum
+    Process 1 __ 3 layers minimum
             <div class="checkbox-container" style="display: inline-block; margin-left: 10px;">
                 <input type="radio" name="gtaw_process" id="gtaw_yes" value="yes" checked>
                 <label for="gtaw_yes">YES</label>
@@ -221,7 +221,7 @@
             </div>
         </td>
         <td class="var-value">
-            <input type="text" class="form-input" name="gtaw_thickness" id="gtaw_thickness" 
+            <input type="text" class="form-input" name="gtaw_thickness" id="gtaw_thickness"
                 placeholder="Enter thickness (mm)" value="14.26" required
                 onchange="calculateThicknessGtawRange(this.value)">
         </td>
@@ -230,9 +230,9 @@
                 placeholder="Max. to be welded" readonly>
         </td>
     </tr>
-
-         <td class="var-label">
-    Process 1 __ 3 layers minimum
+    <tr>
+        <td class="var-label">
+    Process 2 __ 3 layers minimum
             <div class="checkbox-container" style="display: inline-block; margin-left: 10px;">
                 <input type="radio" name="smaw_process" id="smaw_yes" value="yes" checked>
                 <label for="smaw_yes">YES</label>
@@ -241,7 +241,7 @@
             </div>
         </td>
         <td class="var-value">
-            <input type="text" class="form-input" name="smaw_thickness" id="smaw_thickness" 
+            <input type="text" class="form-input" name="smaw_thickness" id="smaw_thickness"
                 placeholder="Enter thickness (mm)" value="14.26" required
                 onchange="calculateThicknessSmawRange(this.value)">
         </td>


### PR DESCRIPTION
This commit addresses several issues in the create, edit, and print views for the GTAW/SMAW certificates.

- The personnel information section in the create/edit form is now mandatory only when RT/UT tests are not selected.
- The 'evaluated_company' field is now always editable.
- The 'certification_text' field is now a required field.
- The 'supervised_company' is now fixed to 'Elite Engineering Arabia'.
- The 'Consumable insert' fields are now readonly instead of disabled to ensure their value is submitted.
- The options for 'Filler Metal Product Form' have been updated.
- The 'Process 1' and 'Process 2' sections in the forms and print view have been swapped.
- A missing 'Consumable insert' field has been added to the print view.