### PR TITLE
Fixes for GTAW/SMAW Certificate Forms and Print View

### DIFF
--- a/resources/views/gtaw_smaw_certificates/partials/welding-variables.blade.php
+++ b/resources/views/gtaw_smaw_certificates/partials/welding-variables.blade.php
@@ -179,8 +179,8 @@
         <td class="var-label">Filler Metal Product Form (QW-404.23) (GTAW or PAW):</td>
         <td class="var-value">
             <select class="form-select" name="filler_product_form" id="filler_product_form" onchange="updateFillerProductFormRange()">
-                <option value="bare (solid or metal cored)">bare (solid or metal cored)</option>
-                <option value="range">flux cored</option>
+                <option value="bare (solid)">bare (solid)</option>
+                <option value="flux cored">flux cored</option>
                 <option value="__manual__">Manual Entry</option>
             </select>
             <input type="text" class="form-input" name="filler_product_form_manual" id="filler_product_form_manual"


### PR DESCRIPTION
This commit addresses several issues in the create, edit, and print views for the GTAW/SMAW certificates.

- The personnel information section in the create/edit form is now mandatory only when RT/UT tests are not selected.
- The 'evaluated_company' field is now always editable.
- The 'certification_text' field is now a required field.
- The 'supervised_company' is now fixed to 'Elite Engineering Arabia'.
- The 'Consumable insert' fields are now readonly instead of disabled to ensure their value is submitted.
- The options for 'Filler Metal Product Form' have been updated.
- The 'Process 1' and 'Process 2' sections in the forms and print view have been swapped.
- A missing 'Consumable insert' field has been added to the print view.
- Corrected the options for 'Filler Metal Product Form' to have the correct values, ensuring the JavaScript logic for displaying the qualified range works as intended.