### PR TITLE
Fixes for GTAW/SMAW Certificate Forms and Print View

### DIFF
--- a/public/css/certificate-form.css
+++ b/public/css/certificate-form.css
@@ -179,6 +179,11 @@ body {
     box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
+.is-invalid {
+    border-color: #dc3545 !important;
+    box-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.25) !important;
+}
+
 .photo-upload:hover {
     background: #e9ecef;
     border-color: #007bff;

--- a/public/js/gtaw-smaw-certificate-form.js
+++ b/public/js/gtaw-smaw-certificate-form.js
@@ -749,30 +749,65 @@ function validateRequiredFields() {
     const requiredFields = document.querySelectorAll('input[required], select[required], textarea[required]');
     let isValid = true;
     let firstInvalidField = null;
-    
+    const invalidFields = [];
+
     requiredFields.forEach(field => {
-        if (!field.value.trim()) {
+        if (!field.disabled && !field.value.trim()) {
             field.classList.add('is-invalid');
             if (!firstInvalidField) {
                 firstInvalidField = field;
             }
             isValid = false;
+
+            let label = '';
+            const labelElement = document.querySelector(`label[for="${field.id}"]`);
+            if (labelElement) {
+                label = labelElement.textContent.trim();
+            } else {
+                const parentTd = field.closest('td');
+                if (parentTd) {
+                    const parentTr = parentTd.closest('tr');
+                    if (parentTr) {
+                        const labelTd = parentTr.querySelector('.var-label');
+                        if (labelTd) {
+                            label = labelTd.textContent.trim().replace(':', '');
+                        }
+                    }
+                }
+            }
+            if (label) {
+                invalidFields.push(label);
+            } else {
+                invalidFields.push(field.name);
+            }
+
         } else {
             field.classList.remove('is-invalid');
         }
     });
-    
-    if (!isValid && firstInvalidField) {
-        firstInvalidField.focus();
-        firstInvalidField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    if (!isValid) {
+        if(firstInvalidField) {
+            firstInvalidField.focus();
+            firstInvalidField.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
         
+        let errorMessage = 'Please fill in all required fields before submitting the form.<br><br>';
+        if(invalidFields.length > 0) {
+            errorMessage += '<b>The following fields are required:</b><br><ul style="text-align: left; margin-left: 20px;">';
+            invalidFields.forEach(fieldName => {
+                errorMessage += `<li>${fieldName}</li>`;
+            });
+            errorMessage += '</ul>';
+        }
+
         Swal.fire({
             icon: 'error',
             title: 'Required Fields Missing',
-            text: 'Please fill in all required fields before submitting the form.'
+            html: errorMessage
         });
     }
-    
+
     return isValid;
 }
 


### PR DESCRIPTION
This commit addresses several issues in the create, edit, and print views for the GTAW/SMAW certificates.

- The personnel information section in the create/edit form is now mandatory only when RT/UT tests are not selected.
- The 'evaluated_company' field is now always editable.
- The 'certification_text' field is now a required field.
- The 'supervised_company' is now fixed to 'Elite Engineering Arabia'.
- The 'Consumable insert' fields are now readonly instead of disabled to ensure their value is submitted.
- The options for 'Filler Metal Product Form' have been updated.
- The 'Process 1' and 'Process 2' sections in the forms and print view have been swapped.
- A missing 'Consumable insert' field has been added to the print view.
- Corrected the options for 'Filler Metal Product Form' to have the correct values, ensuring the JavaScript logic for displaying the qualified range works as intended.
- Improved validation handling to display a list of required fields that are missing.