### PR TITLE
I've fixed the welder and company selection in the SAW certificate fo…

### DIFF
--- a/public/js/saw-certificate-form.js
+++ b/public/js/saw-certificate-form.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', function () {
         welderSelect.on('select2:select', function (e) {
             const welderId = e.params.data.id;
             if (welderId) {
-                fetch(`/api/welders/${welderId}`)
+                fetch(`/api/welders/${welderId}/details`)
                     .then(response => response.json())
                     .then(data => {
                         if (data.welder) {
@@ -54,6 +54,11 @@ document.addEventListener('DOMContentLoaded', function () {
                             if (data.company) {
                                 $('#company_id').val(data.company.id).trigger('change');
                             }
+
+                            // Set certificate and report numbers
+                            $('#certificate_no').val(data.certificate_no || '');
+                            $('#vt_report_no').val(data.vt_report_no || '');
+                            $('#rt_report_no').val(data.rt_report_no || '');
                         }
                     })
                     .catch(error => console.error('Error fetching welder details:', error));

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,9 +23,9 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::get('/welders/search', [App\Http\Controllers\WelderController::class, 'search'])->name('welders.search');
-Route::get('/welders/{id}', [App\Http\Controllers\SawCertificateController::class, 'getWelderDetails'])->name('welders.details');
 
 // API routes using ApiController - Unified certificate endpoints
+Route::get('/welders/{id}/details', [App\Http\Controllers\SawCertificateController::class, 'getWelderDetails'])->name('welders.details');
 Route::get('/welders/{id}', [ApiController::class, 'getWelder'])->name('api.welders.show');
 Route::get('/welders/{id}/{certificateType}', [ApiController::class, 'getWelder'])->name('api.welders.certificate');
 Route::get('/welders/{id}/all-certificates/numbers', [ApiController::class, 'getAllCertificateNumbers'])->name('api.welders.all-certificates');


### PR DESCRIPTION
…rm to match the behavior of the GTAW certificate form. Here's a breakdown of what I did:

1.  **Added `getWelderDetails` to `SawCertificateController`:** I added a new method to the `SawCertificateController` to fetch all the necessary data for a selected welder, including their company details and generated certificate/report numbers.
2.  **Updated Javascript for Welder Search:** I updated the `saw-certificate-form.js` to use the new `getWelderDetails` endpoint. When a welder is selected, the form is now populated with all the relevant data, and the company dropdown is automatically set to the welder's company.
3.  **Corrected API Routes:** I updated the API routes to avoid conflicts and to correctly point to the new `getWelderDetails` method.