### PR TITLE
Fix welder search functionality in SAW certificate form

### DIFF
--- a/app/Http/Controllers/SawCertificateController.php
+++ b/app/Http/Controllers/SawCertificateController.php
@@ -102,7 +102,7 @@ class SawCertificateController extends Controller
     {
         // Get companies for dropdown
         $companies = Company::orderBy('name')->get();
-        $welders = Welder::orderBy('name')->get();
+        $welders = Welder::with('company')->orderBy('name')->get();
 
         // Get current user information
         $user = Auth::user();
@@ -486,7 +486,7 @@ class SawCertificateController extends Controller
     {
         $certificate = SawCertificate::findOrFail($id);
         $companies = Company::orderBy('name')->get();
-        $welders = Welder::orderBy('name')->get();
+        $welders = Welder::with('company')->orderBy('name')->get();
         $selectedWelder = $certificate->welder;
 
         // Define common options for dropdowns

--- a/public/js/saw-certificate-form.js
+++ b/public/js/saw-certificate-form.js
@@ -1,80 +1,57 @@
-document.addEventListener('DOMContentLoaded', function () {
-    // Initialize welder search with Select2
-    const welderSelect = $('.welder-search');
-
-    if (welderSelect.length) {
-        welderSelect.select2({
-            theme: 'bootstrap-5',
-            placeholder: 'Search for a welder...',
-            minimumInputLength: 2,
-            ajax: {
-                url: '/api/welders/search', // Note: We will need to create this route
-                dataType: 'json',
-                delay: 250,
-                data: function (params) {
-                    return {
-                        q: params.term // search term
-                    };
-                },
-                processResults: function (data) {
-                    return {
-                        results: $.map(data, function (welder) {
-                            return {
-                                id: welder.id,
-                                text: welder.name + ' (' + welder.welder_no + ')'
-                            };
-                        })
-                    };
-                },
-                cache: true
-            }
-        });
-
-        // Handle welder selection
-        welderSelect.on('select2:select', function (e) {
-            const welderId = e.params.data.id;
-            if (welderId) {
-                fetch(`/api/welders/${welderId}/details`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.welder) {
-                            $('#welder_id_no').val(data.welder.welder_id_no || '');
-                            $('#iqama_no').val(data.welder.iqama_no || '');
-                            $('#passport_no').val(data.welder.passport_no || '');
-
-                            // Update photo if available
-                            const photoPreview = $('#photo-preview');
-                            if (data.welder.photo_path && photoPreview.length) {
-                                photoPreview.html(`<img src="${data.welder.photo_path}" alt="Welder Photo" class="preview-image">`);
-                            } else {
-                                photoPreview.html('<div class="photo-placeholder">No Photo</div>');
-                            }
-
-                            // Set company if it exists
-                            if (data.company) {
-                                $('#company_id').val(data.company.id).trigger('change');
-                            }
-
-                            // Set certificate and report numbers
-                            $('#certificate_no').val(data.certificate_no || '');
-                            $('#vt_report_no').val(data.vt_report_no || '');
-                            $('#rt_report_no').val(data.rt_report_no || '');
-                        }
-                    })
-                    .catch(error => console.error('Error fetching welder details:', error));
-            }
-        });
+function sawLoadWelderData(welderId) {
+    if (!welderId) {
+        return;
     }
 
-    // Function to preview photo on file input change
-    window.previewPhoto = function(input) {
-        const preview = document.getElementById('photo-preview');
-        if (input.files && input.files[0]) {
-            const reader = new FileReader();
-            reader.onload = function(e) {
-                preview.innerHTML = `<img src="${e.target.result}" alt="Photo Preview" class="preview-image">`;
-            };
-            reader.readAsDataURL(input.files[0]);
-        }
+    fetch(`/api/welders/${welderId}/details`)
+        .then(response => response.json())
+        .then(data => {
+            if (data.welder) {
+                document.getElementById('welder_id_no').value = data.welder.welder_id_no || '';
+                document.getElementById('iqama_no').value = data.welder.iqama_no || '';
+                document.getElementById('passport_no').value = data.welder.passport_no || '';
+
+                // Update photo if available
+                const photoPreview = document.getElementById('photo-preview');
+                if (data.welder.photo_path) {
+                    photoPreview.innerHTML = `<img src="${data.welder.photo_path}" alt="Welder Photo" class="preview-image">`;
+                } else {
+                    photoPreview.innerHTML = '<div class="photo-placeholder">No Photo</div>';
+                }
+
+                // Set company if it exists
+                if (data.company) {
+                    const companySelect = document.getElementById('company_id');
+                    companySelect.value = data.company.id;
+                    // Trigger change event if you are using other libraries that depend on it
+                    // var event = new Event('change');
+                    // companySelect.dispatchEvent(event);
+                }
+
+                // Set certificate and report numbers
+                document.getElementById('certificate_no').value = data.certificate_no || '';
+
+                const vtReportNo = document.getElementById('vt_report_no');
+                if(vtReportNo) {
+                    vtReportNo.value = data.vt_report_no || '';
+                }
+
+                const rtReportNo = document.getElementById('rt_report_no');
+                if(rtReportNo) {
+                    rtReportNo.value = data.rt_report_no || '';
+                }
+            }
+        })
+        .catch(error => console.error('Error fetching welder details:', error));
+}
+
+function previewPhoto(input) {
+    const preview = document.getElementById('photo-preview');
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            preview.innerHTML = `<img src="${e.target.result}" alt="Photo Preview" class="preview-image">`;
+        };
+        reader.readAsDataURL(input.files[0]);
     }
-});
+}

--- a/resources/views/saw_certificates/partials/certificate-details.blade.php
+++ b/resources/views/saw_certificates/partials/certificate-details.blade.php
@@ -10,10 +10,11 @@
         </div>
         <div class="cert-center">
             <strong>Welding Operator's name:</strong>
-            <select class="form-input welder-search" name="welder_id" id="welder_id" required>
-                @if(isset($certificate) && $certificate->welder)
-                    <option value="{{ $certificate->welder->id }}" selected>{{ $certificate->welder->name }}</option>
-                @endif
+            <select class="form-input" name="welder_id" id="welder_id" required onchange="sawLoadWelderData(this.value)">
+                <option value="">Select Welder</option>
+                @foreach($welders as $welder)
+                    <option value="{{ $welder->id }}" {{ old('welder_id', $certificate->welder_id ?? '') == $welder->id ? 'selected' : '' }}>{{ $welder->name }}</option>
+                @endforeach
             </select>
         </div>
         <div class="cert-right">


### PR DESCRIPTION
This commit refactors the welder search functionality in the SAW certificate form to match the implementation in the GTAW certificate form.

The following changes were made:

1.  **Removed Select2:** The Select2 implementation for welder search has been removed.
2.  **Pre-populated Welder Dropdown:** The `SawCertificateController` now fetches all welders and passes them to the `create` and `edit` views, so the welder dropdown is pre-populated.
3.  **Javascript Update:** The `saw-certificate-form.js` file has been updated to include a `sawLoadWelderData` function that is called when a welder is selected from the dropdown. This function fetches the welder's details, including their company and generated certificate/report numbers, and populates the form accordingly.