### PR TITLE
I've fixed the API call in `saw-certificate-form.js` to use the corre…

### DIFF
--- a/public/js/saw-certificate-form.js
+++ b/public/js/saw-certificate-form.js
@@ -3,7 +3,7 @@ function sawLoadWelderData(welderId) {
         return;
     }
 
-    fetch(`/api/welders/${welderId}/details`)
+    fetch(`/welders/${welderId}/details`)
         .then(response => response.json())
         .then(data => {
             if (data.welder) {


### PR DESCRIPTION
…ct route for fetching welder details. I removed the `/api` prefix from the fetch URL to match the route defined in `routes/web.php`.