### PR TITLE
Fix view not found error in SawCertificateController

### DIFF
--- a/app/Http/Controllers/SawCertificateController.php
+++ b/app/Http/Controllers/SawCertificateController.php
@@ -794,7 +794,7 @@ class SawCertificateController extends Controller
         $verificationUrl = route('saw-certificates.verify', ['id' => $certificate->id, 'code' => $certificate->verification_code]);
         $qrCodeUrl = 'data:image/png;base64,' . base64_encode(FacadesQrCode::format('png')->size(200)->generate($verificationUrl));
 
-        return view('saw_certificates.certificate_updated', compact('certificate', 'qrCodeUrl', 'logoPath', 'logoExists'));
+        return view('saw_certificates.certificate', compact('certificate', 'qrCodeUrl', 'logoPath', 'logoExists'));
     }
 
     /**


### PR DESCRIPTION
This commit fixes an error that occurred when trying to print a SAW certificate. The `generateCertificate` method in `SawCertificateController` was attempting to load a view named `saw_certificates.certificate_updated`, which does not exist.

The method has been corrected to load the correct view, `saw_certificates.certificate`.