### PR TITLE
Fix date format error in SAW certificate edit form

### DIFF
--- a/app/Models/SawCertificate.php
+++ b/app/Models/SawCertificate.php
@@ -77,6 +77,7 @@ class SawCertificate extends Model
         'rt' => 'boolean',
         'ut' => 'boolean',
         'test_date' => 'date',
+        'witness_date' => 'date',
         'inspector_date' => 'date'
     ];
 


### PR DESCRIPTION
This commit fixes a "Call to a member function format() on string" error that occurred when opening the edit form for a SAW certificate.

The `witness_date` field was not being cast to a Carbon object in the `SawCertificate` model, which caused the error when the view tried to format the date. This has been fixed by adding `witness_date` to the `$casts` array in the model.