### PR TITLE
Implement range logic for SAW certificate form

### DIFF
--- a/public/js/saw-certificate-form.js
+++ b/public/js/saw-certificate-form.js
@@ -23,9 +23,6 @@ function sawLoadWelderData(welderId) {
                 if (data.company) {
                     const companySelect = document.getElementById('company_id');
                     companySelect.value = data.company.id;
-                    // Trigger change event if you are using other libraries that depend on it
-                    // var event = new Event('change');
-                    // companySelect.dispatchEvent(event);
                 }
 
                 // Set certificate and report numbers
@@ -55,3 +52,61 @@ function previewPhoto(input) {
         reader.readAsDataURL(input.files[0]);
     }
 }
+
+function updateSawRange(fieldType) {
+    const value = document.querySelector(`[name="${fieldType}"]`).value;
+    const rangeSpan = document.getElementById(`${fieldType}_range`);
+    const hiddenField = document.querySelector(`[name="${fieldType}_range"]`);
+
+    let range = '';
+
+    switch (fieldType) {
+        case 'welding_type':
+            range = value;
+            break;
+        case 'welding_process':
+            range = value;
+            break;
+        case 'visual_control_type':
+            range = value;
+            break;
+        case 'joint_tracking':
+            if (value === 'With Automatic joint tracking') {
+                range = 'With Automatic joint tracking';
+            } else {
+                range = 'With & Without Automatic joint tracking';
+            }
+            break;
+        case 'backing':
+            if (value === 'With backing') {
+                range = 'With backing';
+            } else {
+                range = 'With or Without backing';
+            }
+            break;
+        case 'passes_per_side':
+            if (value === 'Single passes per side') {
+                range = 'Single passes per side';
+            } else {
+                range = 'Single & multiple passes per side';
+            }
+            break;
+    }
+
+    if (rangeSpan) {
+        rangeSpan.textContent = range;
+    }
+
+    if (hiddenField) {
+        hiddenField.value = range;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    updateSawRange('welding_type');
+    updateSawRange('welding_process');
+    updateSawRange('visual_control_type');
+    updateSawRange('joint_tracking');
+    updateSawRange('backing');
+    updateSawRange('passes_per_side');
+});

--- a/resources/views/saw_certificates/partials/testing-variables-machine.blade.php
+++ b/resources/views/saw_certificates/partials/testing-variables-machine.blade.php
@@ -11,7 +11,7 @@
     <tr>
         <td class="var-label">Type of welding (Machine):</td>
         <td class="var-value">
-            <select class="form-input" name="welding_type">
+            <select class="form-input" name="welding_type" onchange="updateSawRange('welding_type')">
                 <option value="Machine" {{ old('welding_type', $certificate->welding_type ?? 'Machine') == 'Machine' ? 'selected' : '' }}>Machine</option>
                 <option value="Automatic" {{ old('welding_type', $certificate->welding_type ?? '') == 'Automatic' ? 'selected' : '' }}>Automatic</option>
             </select>
@@ -24,7 +24,7 @@
     <tr>
         <td class="var-label">Welding process:</td>
         <td class="var-value">
-            <select class="form-input" name="welding_process">
+            <select class="form-input" name="welding_process" onchange="updateSawRange('welding_process')">
                 <option value="SAW" {{ old('welding_process', $certificate->welding_process ?? 'SAW') == 'SAW' ? 'selected' : '' }}>SAW</option>
                 <option value="GTAW" {{ old('welding_process', $certificate->welding_process ?? '') == 'GTAW' ? 'selected' : '' }}>GTAW</option>
                 <option value="GMAW" {{ old('welding_process', $certificate->welding_process ?? '') == 'GMAW' ? 'selected' : '' }}>GMAW</option>
@@ -39,7 +39,7 @@
     <tr>
         <td class="var-label">Direct or remote visual control:</td>
         <td class="var-value">
-            <select class="form-input" name="visual_control_type" onchange="updateVisualControlRange()">
+            <select class="form-input" name="visual_control_type" onchange="updateSawRange('visual_control_type')">
                 <option value="Direct Visual Control" {{ old('visual_control_type', $certificate->visual_control_type ?? 'Direct Visual Control') == 'Direct Visual Control' ? 'selected' : '' }}>Direct Visual Control</option>
                 <option value="Remote Visual Control" {{ old('visual_control_type', $certificate->visual_control_type ?? '') == 'Remote Visual Control' ? 'selected' : '' }}>Remote Visual Control</option>
             </select>
@@ -65,7 +65,7 @@
     <tr>
         <td class="var-label">Automatic joint tracking:</td>
         <td class="var-value">
-            <select class="form-input" name="joint_tracking" onchange="updateJointTrackingRange()">
+            <select class="form-input" name="joint_tracking" onchange="updateSawRange('joint_tracking')">
                 <option value="With Automatic joint tracking" {{ old('joint_tracking', $certificate->joint_tracking ?? 'With Automatic joint tracking') == 'With Automatic joint tracking' ? 'selected' : '' }}>With Automatic joint tracking</option>
                 <option value="Without Automatic joint tracking" {{ old('joint_tracking', $certificate->joint_tracking ?? '') == 'Without Automatic joint tracking' ? 'selected' : '' }}>Without Automatic joint tracking</option>
             </select>
@@ -103,7 +103,7 @@
     <tr>
         <td class="var-label">Backing (with or without):</td>
         <td class="var-value">
-            <select class="form-input" name="backing" id="backing" onchange="updateBackingRange()">
+            <select class="form-input" name="backing" id="backing" onchange="updateSawRange('backing')">
                 <option value="With backing" {{ old('backing', $certificate->backing ?? 'With backing') == 'With backing' ? 'selected' : '' }}>With backing</option>
                 <option value="Without backing" {{ old('backing', $certificate->backing ?? '') == 'Without backing' ? 'selected' : '' }}>Without backing</option>
             </select>
@@ -116,7 +116,7 @@
     <tr>
         <td class="var-label">Single or multiple passes per side:</td>
         <td class="var-value">
-            <select class="form-input" name="passes_per_side" onchange="updatePassesRange()">
+            <select class="form-input" name="passes_per_side" onchange="updateSawRange('passes_per_side')">
                 <option value="Single passes per side" {{ old('passes_per_side', $certificate->passes_per_side ?? '') == 'Single passes per side' ? 'selected' : '' }}>Single passes per side</option>
                 <option value="multiple passes per side" {{ old('passes_per_side', $certificate->passes_per_side ?? 'multiple passes per side') == 'multiple passes per side' ? 'selected' : '' }}>multiple passes per side</option>
             </select>


### PR DESCRIPTION
This commit implements the logic for automatically populating the "Range Qualified" column based on the "Actual Values" selected in the SAW certificate form.

The following changes were made:

1.  **Updated View Partial:** The `testing-variables-machine.blade.php` partial has been updated to include `onchange` event handlers on the relevant select elements.
2.  **Updated Javascript:** The `saw-certificate-form.js` file has been updated with a new `updateSawRange` function that contains the logic for updating the range values. A `DOMContentLoaded` event listener has also been added to initialize the ranges when the page loads.